### PR TITLE
Travis: remove duplicate job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ cache: pip
 matrix:
   include:
   - python: "2.7"
+    env: HADOOP_MAJOR_VERSION=2
+  - python: "2.7"
+    env: HADOOP_MAJOR_VERSION=3
   - python: "3.6"
+    env: HADOOP_MAJOR_VERSION=3
   - python: "3.7"
-    sudo: required
+    env: HADOOP_MAJOR_VERSION=3
     dist: xenial
-
-env:
-  - HADOOP_MAJOR_VERSION=2
-  - HADOOP_MAJOR_VERSION=3
 
 sudo: required
 


### PR DESCRIPTION
Proposed changes for crs4#324. In https://travis-ci.org/crs4/pydoop/builds/411017941, jobs 515.1 and 515.3 are duplicate. This PR brings the build total back to four. See https://travis-ci.org/simleo/pydoop/builds/411193670 for the outcome.